### PR TITLE
fix warning text positioning

### DIFF
--- a/components/PasswordInput.vue
+++ b/components/PasswordInput.vue
@@ -44,7 +44,7 @@
     </div>
 
     <!-- Warning text for incorrect password -->
-    <div v-if="showWarning" class="text-red-500 text-sm mt-2">Incorrect passcode, please try again.</div>
+    <div v-if="showWarning" class="text-red-500 text-sm absolute">Incorrect passcode, please try again.</div>
   </div>
 </template>
 


### PR DESCRIPTION
#23
**Adjust the warning text to float over the input fields without shifting the layout**
- position: absolute