### PR TITLE
Refactor StoryComponent.vue to improve layout and content rendering

### DIFF
--- a/components/StoryComponent.vue
+++ b/components/StoryComponent.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="w-full h-44" >
-    <div class="story-container relative items-center justify-center p-4">
+  <div class="w-full h-44">
+    <div class="story-container relative p-4">
       <transition name="fade" mode="out-in">
-        <div :key="content.id" class="story-content font-kanit text-lg">{{ content.content }}</div>
+        <div :key="content.id" class="story-content font-kanit text-lg" v-html="content.content"></div>
       </transition>
     </div>
   </div>
@@ -19,11 +19,14 @@ const props = defineProps({
 
 <style scoped>
 .story-container {
+  display: flex;
   text-align: center;
-  margin-top: 2rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }
 
-  
 .fade-enter-active, .fade-leave-active {
   transition: opacity 0.5s ease;
 }


### PR DESCRIPTION
This pull request contain 2 cards
#28 : br tag doesn't rendered as a html element
#35 : Make text in story page real center in vertical

Changes to layout and styling:

* [`components/StoryComponent.vue`](diffhunk://#diff-d0ed53b4f4db442d69e8a95e91e309eb69072a4a59d6e5e26011519db2b6ee60L3-R5): Removed unnecessary `items-center` and `justify-center` classes from the `story-container` and added `display: flex`, `flex-direction: column`, `justify-content: center`, and `align-items: center` to center the content both horizontally and vertically. [[1]](diffhunk://#diff-d0ed53b4f4db442d69e8a95e91e309eb69072a4a59d6e5e26011519db2b6ee60L3-R5) [[2]](diffhunk://#diff-d0ed53b4f4db442d69e8a95e91e309eb69072a4a59d6e5e26011519db2b6ee60R22-L26)

Changes to content rendering:

* [`components/StoryComponent.vue`](diffhunk://#diff-d0ed53b4f4db442d69e8a95e91e309eb69072a4a59d6e5e26011519db2b6ee60L3-R5): Updated the `story-content` div to use `v-html` for rendering HTML content, allowing for richer text formatting.